### PR TITLE
validation 방식 변경 및 test cases 추가

### DIFF
--- a/webhook/validation.go
+++ b/webhook/validation.go
@@ -65,7 +65,6 @@ func validate(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	}
 
 	// Parse the AdmissionReview request
-
 	var admissionReviewReq admissionv1.AdmissionReview
 	if _, _, err := universalDeserializer.Decode(body, nil, &admissionReviewReq); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -76,7 +75,6 @@ func validate(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	}
 
 	// Construct the AdmissionReview response
-
 	admissionReviewResponse := admissionv1.AdmissionReview{
 		Response: &admissionv1.AdmissionResponse{
 			UID: admissionReviewReq.Request.UID,
@@ -122,11 +120,40 @@ func validateGpu(req *admissionv1.AdmissionRequest) error {
 		return fmt.Errorf("could not deserialize pod object: %v", err)
 	}
 
-	extendedResourcesUsedByPod := GetExtendResourcesUsedByPod(&pod)
-	extenedResourceTolerationsUsedByPod := GetExtendResourceTolerationsUsedByPod(&pod)
+	if err := validatePodLimits(&pod.Spec); err != nil {
+		return fmt.Errorf("Forbidden Toleration Usage: %v", err)
+	}
 
-	if !(*extenedResourceTolerationsUsedByPod).IsSubset(*extendedResourcesUsedByPod) {
-		return fmt.Errorf("Forbidden Toleration Usage")
+	return nil
+}
+
+func validatePodLimits(podSpec *corev1.PodSpec) error {
+	if len(podSpec.Tolerations) == 0 {
+		return fmt.Errorf("Empty toleration")
+	}
+
+	var resourceNames map[corev1.ResourceName]struct{}
+	resourceNames = make(map[corev1.ResourceName]struct{})
+	for _, container := range podSpec.InitContainers {
+		for resourceName := range container.Resources.Limits {
+			if _, ok := resourceNames[resourceName]; !ok {
+				resourceNames[resourceName] = struct{}{}
+			}
+		}
+	}
+
+	for _, container := range podSpec.Containers {
+		for resourceName := range container.Resources.Limits {
+			if _, ok := resourceNames[resourceName]; !ok {
+				resourceNames[resourceName] = struct{}{}
+			}
+		}
+	}
+
+	for _, toleration := range podSpec.Tolerations {
+		if _, ok := resourceNames[corev1.ResourceName(toleration.Key)]; !ok {
+			return fmt.Errorf("Untolerated key: %v", toleration.Key)
+		}
 	}
 
 	return nil

--- a/webhook/validation.go
+++ b/webhook/validation.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,7 +66,7 @@ func validate(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 
 	// Parse the AdmissionReview request
 
-	var admissionReviewReq v1beta1.AdmissionReview
+	var admissionReviewReq admissionv1.AdmissionReview
 	if _, _, err := universalDeserializer.Decode(body, nil, &admissionReviewReq); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return nil, fmt.Errorf("could not deserialize request: %v", err)
@@ -77,8 +77,8 @@ func validate(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 
 	// Construct the AdmissionReview response
 
-	admissionReviewResponse := v1beta1.AdmissionReview{
-		Response: &v1beta1.AdmissionResponse{
+	admissionReviewResponse := admissionv1.AdmissionReview{
+		Response: &admissionv1.AdmissionResponse{
 			UID: admissionReviewReq.Request.UID,
 		},
 	}
@@ -105,7 +105,7 @@ func validate(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 
 // validateGpu validates wether the given request has permission on
 // using GPU device.
-func validateGpu(req *v1beta1.AdmissionRequest) error {
+func validateGpu(req *admissionv1.AdmissionRequest) error {
 	// This handler should only get called on Pod objects.
 	// However, if different kind of object is invoked, issue a log message
 	// but let the object request pass through.

--- a/webhook/validation_test.go
+++ b/webhook/validation_test.go
@@ -8,12 +8,87 @@ import (
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
+func marshal(p corev1.Pod) []byte {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+
+	return b
+}
+
 func TestValidate(t *testing.T) {
 	uid := types.UID("12D3FG")
+	gpuResourceName := "nvidia.com/gpu" // TODO: gpu device list 관리 필요
+	gpuPod := []corev1.Pod{
+		{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceName(gpuResourceName): *resource.NewQuantity(1, resource.DecimalSI),
+							},
+						},
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      gpuResourceName,
+						Operator: "NoSchedule",
+					},
+					{
+						Key:      gpuResourceName,
+						Operator: "NoExecute",
+					},
+				},
+			},
+		},
+		{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceName(gpuResourceName): *resource.NewQuantity(1, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI),
+							},
+						},
+					},
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      gpuResourceName,
+						Operator: "NoSchedule",
+					},
+					{
+						Key:      gpuResourceName,
+						Operator: "NoExecute",
+					},
+				},
+			},
+		},
+	}
+
 	cases := []struct {
 		in   admissionv1.AdmissionReview
 		want string
@@ -21,9 +96,23 @@ func TestValidate(t *testing.T) {
 		{
 			in: admissionv1.AdmissionReview{
 				TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
-				Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource},
+				Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource, Object: runtime.RawExtension{Raw: marshal(gpuPod[0])}},
 			},
 			want: `{"response":{"uid":"` + string(uid) + `","allowed":true}}`,
+		},
+		{
+			in: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
+				Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource, Object: runtime.RawExtension{Raw: marshal(gpuPod[1])}},
+			},
+			want: `{"response":{"uid":"` + string(uid) + `","allowed":false,"status":{"metadata":{},"message":"Forbidden Toleration Usage: Empty toleration"}}}`,
+		},
+		{
+			in: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
+				Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource, Object: runtime.RawExtension{Raw: marshal(gpuPod[2])}},
+			},
+			want: `{"response":{"uid":"` + string(uid) + `","allowed":false,"status":{"metadata":{},"message":"Forbidden Toleration Usage: Untolerated key: nvidia.com/gpu"}}}`,
 		},
 	}
 

--- a/webhook/validation_test.go
+++ b/webhook/validation_test.go
@@ -7,17 +7,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestValidate(t *testing.T) {
 	uid := types.UID("12D3FG")
-	request := v1beta1.AdmissionReview{
+
+	request := admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
-		Request:  &v1beta1.AdmissionRequest{UID: uid, Resource: podResource},
-		Response: &v1beta1.AdmissionResponse{},
+		Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource},
 	}
 
 	pbytes, err := json.Marshal(request)

--- a/webhook/validation_test.go
+++ b/webhook/validation_test.go
@@ -14,42 +14,50 @@ import (
 
 func TestValidate(t *testing.T) {
 	uid := types.UID("12D3FG")
-
-	request := admissionv1.AdmissionReview{
-		TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
-		Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource},
+	cases := []struct {
+		in   admissionv1.AdmissionReview
+		want string
+	}{
+		{
+			in: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{Kind: "pods", APIVersion: "v1"},
+				Request:  &admissionv1.AdmissionRequest{UID: uid, Resource: podResource},
+			},
+			want: `{"response":{"uid":"` + string(uid) + `","allowed":true}}`,
+		},
 	}
 
-	pbytes, err := json.Marshal(request)
-	if err != nil {
-		t.Errorf("marshaling response: %v", err)
-	}
-	buff := bytes.NewBuffer(pbytes)
+	for _, c := range cases {
+		pbytes, err := json.Marshal(c.in)
+		if err != nil {
+			t.Errorf("marshaling response: %v", err)
+		}
+		buff := bytes.NewBuffer(pbytes)
 
-	req, err := http.NewRequest("POST", "/validate", buff)
-	if err != nil {
-		t.Error()
-	}
-	req.Header.Set("Content-Type", "application/json")
+		req, err := http.NewRequest("POST", "/validate", buff)
+		if err != nil {
+			t.Error()
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(HandleValidate)
+		// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(HandleValidate)
 
-	// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
-	// directly and pass in our Request and ResponseRecorder.
-	handler.ServeHTTP(rr, req)
+		// Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+		// directly and pass in our Request and ResponseRecorder.
+		handler.ServeHTTP(rr, req)
 
-	// Check the status code is what we expect.
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
-	}
+		// Check the status code is what we expect.
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
 
-	// Check the response body is what we expect.
-	expected := `{"response":{"uid":"` + string(uid) + `","allowed":true}}`
-	if rr.Body.String() != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v",
-			rr.Body.String(), expected)
+		// Check the response body is what we expect.
+		if rr.Body.String() != c.want {
+			t.Errorf("handler returned unexpected body: got %v want %v",
+				rr.Body.String(), c.want)
+		}
 	}
 }


### PR DESCRIPTION
- validation 방식을 container resources의 request에 대해서 비교하는 방식에서 limits으로 변경
  - 참고:  https://kubernetes.io/ko/docs/tasks/manage-gpus/scheduling-gpus/
- test cases 추가하여 테스트 진행
  1. Resource에 gpu를 사용하는데, tolerations가 정의 된 경우 - true
  2. Resource에 gpu를 사용하지만, tolerations가 정의 되지 않은 경우 - false, empty toleration
  3. Resource에 명시 되지 않았으나, tolerations가 정의 된 경우 - false, forbidden toleration usage